### PR TITLE
fix: round amount before int cast to preserve decimal fils

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -45,7 +45,7 @@ class AuthorizeRequest extends AbstractRequest implements MessageInterface
 
 		$params = [
 			'source' => $source,
-			'amount' => (int)$parameters['amount'] * 100,
+			'amount' => $parameters['amount'] * 100,
 			'currency' => strtoupper($parameters['currency']),
 			'success_url' => $parameters['returnUrl'] ?? null,
 			'failure_url' => $parameters['cancelUrl'] ?? null,


### PR DESCRIPTION
## Summary
- `(int)$parameters['amount'] * 100` casts to int **before** multiplying, truncating the decimal portion
- e.g. AED 682.50 → `(int)682.50` = 682 × 100 = 68,200 fils (50 fils short)
- Fix: `(int)round($parameters['amount'] * 100)` — multiplies first, then rounds to nearest integer, then casts safely

## Change
```php
// Before (bug):
'amount' => (int)$parameters['amount'] * 100,

// After (fix):
'amount' => (int)round($parameters['amount'] * 100),
```